### PR TITLE
:ambulance: feat(retry-mechanism): Implement server error retry for k…

### DIFF
--- a/boost.common/pom.xml
+++ b/boost.common/pom.xml
@@ -18,6 +18,10 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.aliyun</groupId>
             <artifactId>aliyun-java-sdk-core</artifactId>
             <version>4.5.2</version>

--- a/boost.common/src/main/java/org/example/common/adapter/impl/AcsApiCallerImpl.java
+++ b/boost.common/src/main/java/org/example/common/adapter/impl/AcsApiCallerImpl.java
@@ -13,7 +13,11 @@ import org.example.common.adapter.AcsApiCaller;
 import org.example.common.config.AliyunConfig;
 import org.example.common.constant.ComputeNestConstants;
 import org.example.common.utils.JsonUtil;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
+
+import java.net.SocketTimeoutException;
 
 @Component
 @Slf4j
@@ -21,6 +25,7 @@ public class AcsApiCallerImpl implements AcsApiCaller {
 
     private IAcsClient client;
 
+    @Retryable(value = {SocketTimeoutException.class, ServerException.class}, maxAttempts = 3, backoff = @Backoff(delay = 2000))
     @Override
     public CommonResponse getCommonResponse(CommonRequest request) throws ClientException {
         try {

--- a/boost.front/src/pages/ServiceInstanceContent/index.tsx
+++ b/boost.front/src/pages/ServiceInstanceContent/index.tsx
@@ -177,6 +177,7 @@ const ServiceInstanceContent: React.FC<ServiceInstanceContentProps> = (props) =>
             }
             const {PayPeriod, type} = await form?.current?.getFieldFormatValue();
             if (order != null && order.specificationName && order.serviceInstanceId) {
+
                 const productComponents = {
                     SpecificationName: order.specificationName,
                     PayPeriod: PayPeriod,
@@ -236,48 +237,48 @@ const ServiceInstanceContent: React.FC<ServiceInstanceContentProps> = (props) =>
                             </div>
                         )}
                     </div>
-                    {source != CallSource[CallSource.Market] && <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>
-                    <ModalForm
-                        title="续费"
-                        size={'large'}
-                        trigger={<Button hidden={renewalAndDeleteVisible}>续费</Button>}
-                        formRef={form}
-                        modalProps={{
-                            destroyOnClose: true,
-                        }}
-                        onFinish={async (values) => {
-                            await renewalServiceInstance();
-                            return true;
-                        }}
-                    >
-                        <div style={{display: 'flex', flexDirection: 'column'}}>
-                                {/*<PayPeriodFormItem onChange={handleOptionChange}/>*/}
-                                <ProFormDigit
-                                    label="包月时间"
-                                    name="PayPeriod"
-                                    key={"PayPeriod"}
-                                    min={1}
-                                    initialValue={1}
-                                    fieldProps={{precision: 0, defaultValue: 1, onChange: (value) => {
-                                            if(value){
-                                                setSelectedMonths(value);
-                                            }}}}
-                                    required={true}
+                {/* Temporarily cancel renewal   {source != CallSource[CallSource.Market] && <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center'}}>*/}
+                {/*    <ModalForm*/}
+                {/*        title="续费"*/}
+                {/*        size={'large'}*/}
+                {/*        trigger={<Button hidden={renewalAndDeleteVisible}>续费</Button>}*/}
+                {/*        formRef={form}*/}
+                {/*        modalProps={{*/}
+                {/*            destroyOnClose: true,*/}
+                {/*        }}*/}
+                {/*        onFinish={async (values) => {*/}
+                {/*            await renewalServiceInstance();*/}
+                {/*            return true;*/}
+                {/*        }}*/}
+                {/*    >*/}
+                {/*        <div style={{display: 'flex', flexDirection: 'column'}}>*/}
+                {/*                /!*<PayPeriodFormItem onChange={handleOptionChange}/>*!/*/}
+                {/*                <ProFormDigit*/}
+                {/*                    label="包月时间"*/}
+                {/*                    name="PayPeriod"*/}
+                {/*                    key={"PayPeriod"}*/}
+                {/*                    min={1}*/}
+                {/*                    initialValue={1}*/}
+                {/*                    fieldProps={{precision: 0, defaultValue: 1, onChange: (value) => {*/}
+                {/*                            if(value){*/}
+                {/*                                setSelectedMonths(value);*/}
+                {/*                            }}}}*/}
+                {/*                    required={true}*/}
 
-                                />
-                                <div className={styles.currentPrice}>
-                                    当前价格:
-                                    <span className={styles.priceValue}>
-                                        {currentPrice ? `     ¥${currentPrice.toFixed(2)}` : " 加载中..."}
-                                    </span>
-                                </div>
-                            <Divider className={styles.msrectangleshape}/>
-                            <div className={styles.specificationTitle}>{"支付方式"}</div>
+                {/*                />*/}
+                {/*                <div className={styles.currentPrice}>*/}
+                {/*                    当前价格:*/}
+                {/*                    <span className={styles.priceValue}>*/}
+                {/*                        {currentPrice ? `     ¥${currentPrice.toFixed(2)}` : " 加载中..."}*/}
+                {/*                    </span>*/}
+                {/*                </div>*/}
+                {/*            <Divider className={styles.msrectangleshape}/>*/}
+                {/*            <div className={styles.specificationTitle}>{"支付方式"}</div>*/}
 
-                            <PayTypeFormItem/>
-                        </div>
-                    </ModalForm>
-                </div>}
+                {/*            <PayTypeFormItem/>*/}
+                {/*        </div>*/}
+                {/*    </ModalForm>*/}
+                {/*</div>}*/}
 
                 </Space>
             </div>

--- a/boost.server/src/main/java/org/example/Server.java
+++ b/boost.server/src/main/java/org/example/Server.java
@@ -19,11 +19,13 @@ package org.example;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableCaching
 @SpringBootApplication
 @EnableScheduling
+@EnableRetry
 public class Server {
     public static void main(String[] args) {
         SpringApplication.run(Server.class, args);

--- a/boost.server/src/main/java/org/example/service/base/impl/ServiceInstanceLifecycleServiceImpl.java
+++ b/boost.server/src/main/java/org/example/service/base/impl/ServiceInstanceLifecycleServiceImpl.java
@@ -233,9 +233,8 @@ public class ServiceInstanceLifecycleServiceImpl implements ServiceInstanceLifec
             CommonRequest commonRequest = buildPayOrderCallbackRequest(orderDO, userInfoModel.getAid());
             CommonResponse commonResponse = acsApiCaller.getCommonResponse(commonRequest);
             if (commonResponse.getHttpStatus() == HttpStatus.SC_OK && StringUtils.isNotEmpty(commonResponse.getData())) {
-                ServiceInstanceModel serviceInstanceModel = JsonUtil.parseObject(commonResponse.getData(), ServiceInstanceModel.class);
-                orderDO.setServiceInstanceId(serviceInstanceModel.getServiceInstanceId());
-                log.info("paOrderCallback success, orderId = {}, serviceInstanceId = {}", orderDO.getOrderId(), serviceInstanceModel.getServiceInstanceId());
+                ServiceInstanceModel serviceInstanceModel = JsonUtil.parseObjectUpperCamelCase(commonResponse.getData(), ServiceInstanceModel.class);
+                log.info("payOrderCallback success, orderId = {}, serviceInstanceId = {}", orderDO.getOrderId(), serviceInstanceModel.getServiceInstanceId());
                 return serviceInstanceModel.getServiceInstanceId();
             } else {
                 throw new BizException(ErrorInfo.SERVICE_INSTANCE_CREATE_FAILED.getStatusCode(), ErrorInfo.SERVICE_INSTANCE_CREATE_FAILED.getCode(),

--- a/boost.server/src/main/java/org/example/service/order/impl/OrderServiceImpl.java
+++ b/boost.server/src/main/java/org/example/service/order/impl/OrderServiceImpl.java
@@ -198,6 +198,7 @@ public class OrderServiceImpl implements OrderService {
         } else {
             String refundId = UuidUtil.generateRefundId();
             alipayService.refundOrder(orderDO.getOrderId(), MoneyUtil.fromCents(orderDO.getReceiptAmount()), refundId);
+            orderDO.setRefundAmount(orderDO.getReceiptAmount());
             orderDO.setTradeStatus(TradeStatus.REFUNDED);
         }
         orderOtsHelper.updateOrder(orderDO);

--- a/boost.serverless/src/main/java/org/example/Serverless.java
+++ b/boost.serverless/src/main/java/org/example/Serverless.java
@@ -17,11 +17,13 @@ package org.example;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @SpringBootApplication
 @EnableScheduling
+@EnableRetry
 public class Serverless {
     public static void main(String[] args) {
         SpringApplication.run(Serverless.class);

--- a/boost.serverless/src/main/java/org/example/task/RefundOrderTask.java
+++ b/boost.serverless/src/main/java/org/example/task/RefundOrderTask.java
@@ -68,10 +68,6 @@ public class RefundOrderTask implements Runnable {
                 OrderDO orderDO = new OrderDO();
                 orderDO.setTradeStatus(TradeStatus.REFUNDED);
                 orderDO.setOrderId(orderId);
-                Boolean alipaySuccess = Boolean.TRUE;
-                if (payChannel != null && payChannel != PayChannel.PAY_POST && refundAmount > 0) {
-                    alipaySuccess = baseAlipayClient.refundOrder(orderId, MoneyUtil.fromCents(refundAmount), refundId);
-                }
                 OrderDTO order = orderOtsHelper.getOrder(orderId, null);
                 Long currentLocalDateTimeMillis = DateUtil.getCurrentLocalDateTimeMillis();
                 if (shouldDeleteServiceInstance(currentLocalDateTimeMillis, order)) {
@@ -81,6 +77,10 @@ public class RefundOrderTask implements Runnable {
                     log.info("Delete service instance status code = {}", deleteServiceInstancesResponse.getStatusCode());
                 }
                 Boolean updateOrder = orderOtsHelper.updateOrder(orderDO);
+                Boolean alipaySuccess = Boolean.TRUE;
+                if (payChannel != null && payChannel != PayChannel.PAY_POST && refundAmount > 0) {
+                    alipaySuccess = baseAlipayClient.refundOrder(orderId, MoneyUtil.fromCents(refundAmount), refundId);
+                }
                 log.info("Alipay refund {}. Update order {}.", alipaySuccess, updateOrder);
                 log.info("Order refund success. order id = {}.", orderDO.getOrderId());
                 success = order.getTradeStatus() == TradeStatus.REFUNDED;


### PR DESCRIPTION

Changes include:
- Addition of a retry policy for order queries, which triggers upon receiving server errors (5xx responses), utilizing an exponential backoff strategy to manage the frequency of retries.
- Implementation of a retry mechanism for handling failures during post-payment callback processing, ensuring successful acknowledgment of payment status even in the event of temporary server unavailability.
- Establishment of a retry process for trade creation actions, aimed at addressing failures due to server errors by attempting the operation again with a sensible delay between attempts.